### PR TITLE
Fix - Reverted 7.3 Dockerfile tag change

### DIFF
--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # syntax=docker/dockerfile:1.3
-FROM phpdockerio/php:7.3-fpm
+FROM phpdockerio/php73-fpm:latest
 
 # Fix debconf warnings upon build
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
This is due to the 7.3 image not yet being available in the new phpdockerio repository.
