### PR TITLE
PHP intl extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Note: The default should be fine for Mac and Windows, if you are on Linux you sh
 - php-gd
 - php-gmp
 - php-imagick
+- php-intl
 - php-json
 - php-mbstring
 - php-mysql

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -45,6 +45,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
             php${PHP_VERSION}-tidy  \
             php${PHP_VERSION}-yaml  \
     		php${PHP_VERSION}-swoole \
+            php${PHP_VERSION}-intl \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
     && echo "pm.max_children = 10" >> /etc/php/${PHP_VERSION}/fpm/pool.d/z-overrides.conf
 


### PR DESCRIPTION
Add support for PHP [Internationalization Functions](https://www.php.net/manual/en/book.intl.php)