### PR TITLE
Enable php assertions

### DIFF
--- a/src/php-ini-overrides.ini
+++ b/src/php-ini-overrides.ini
@@ -7,6 +7,7 @@ memory_limit=512M
 post_max_size = 150M
 upload_max_filesize = 128M
 upload_tmp_dir=/var/tmp
+zend.assertions=1
 
 [xdebug]
 # Refer to the dockerfile or readme for information regarding the client_host.


### PR DESCRIPTION
This PR enables PHP's `assert()` function checks for doing assertions in development.